### PR TITLE
Refactor needed to add support for multiple input types

### DIFF
--- a/browser-extension/src/content-scripts/main.js
+++ b/browser-extension/src/content-scripts/main.js
@@ -43,7 +43,7 @@ function tryReinit() {
 // Returns true if any code mirrors are found on the page
 function hasCodeMirrors() {
   debug("Checking for CodeMirrors...");
-  const result = !!document.querySelector(".CodeMirror");
+  const result = CodeInputs.hasCodeElements();
   debug("CodeMirrors found:", result);
   return result;
 }

--- a/browser-extension/src/content-scripts/main.js
+++ b/browser-extension/src/content-scripts/main.js
@@ -1,6 +1,6 @@
 // https://developer.chrome.com/docs/extensions/mv3/content_scripts/#host-page-communication
 import { initWindowState } from "../lib/util";
-import { ResurfaceCodeMirrorInput } from "../lib/inputs";
+import { CodeInputs } from "../lib/inputs";
 
 initWindowState(window);
 let codeMirrors;
@@ -13,7 +13,7 @@ const error = (...args) =>
 
 // Create editor buttons and listen for events
 function init() {
-  codeMirrors = new ResurfaceCodeMirrorInput(postMessageToProxy)
+  codeMirrors = new CodeInputs(postMessageToProxy)
   if (!codeMirrors.hasInputs)
     return debug("No CodeMirrors found");
   listen();

--- a/browser-extension/src/content-scripts/main.js
+++ b/browser-extension/src/content-scripts/main.js
@@ -1,11 +1,9 @@
 // https://developer.chrome.com/docs/extensions/mv3/content_scripts/#host-page-communication
 import { initWindowState } from "../lib/util";
+import { ResurfaceCodeMirrorInput } from "../lib/inputs";
 
 initWindowState(window);
-let buttons = [];
-let codeMirrors = [];
-const buttonBg = "#133d65";
-const buttonText = "white";
+let codeMirrors;
 
 const logPrefix = "[DOM]";
 const debug = (...args) =>
@@ -15,26 +13,17 @@ const error = (...args) =>
 
 // Create editor buttons and listen for events
 function init() {
-  codeMirrors = getAllCodeMirrors();
-  if (!codeMirrors || codeMirrors.length === 0)
+  codeMirrors = new ResurfaceCodeMirrorInput(postMessageToProxy)
+  if (!codeMirrors.hasInputs)
     return debug("No CodeMirrors found");
-  buttons = attachButtons(codeMirrors);
   listen();
 }
 
 // Remove buttons and stop listening
 function destroy() {
-  const orphanedButtons = getAllButtons();
-  const allButtons = (
-    orphanedButtons ? [...buttons, ...orphanedButtons] : buttons
-  ).filter(Boolean);
-  allButtons.forEach((button) => {
-    const mirrorId = button.dataset.resurfaceMirrorId;
-    postMessageToProxy({ type: "closeEditor", mirrorId, recipient: "editor" });
-    button.remove();
-  });
-  buttons = [];
-  codeMirrors = [];
+  if(codeMirrors){
+    codeMirrors.destroy();
+  }
   unlisten();
 }
 
@@ -59,25 +48,6 @@ function hasCodeMirrors() {
   return result;
 }
 
-// Get all CodeMirror instances on this page
-function getAllCodeMirrors() {
-  const foundMirrors = Array.from(document.querySelectorAll(".CodeMirror"));
-  return foundMirrors.length > 0 && foundMirrors.filter(Boolean);
-}
-
-// Get all "open resurface editor" buttons on this page
-function getAllButtons() {
-  const foundButtons = Array.from(
-    document.querySelectorAll(".resurface-editor-button")
-  );
-  return foundButtons.length > 0 && foundButtons.filter(Boolean);
-}
-
-// Return current value of given CodeMirror
-function getValue(codeMirror) {
-  return codeMirror.CodeMirror.doc.getValue();
-}
-
 // Send message to proxy content script on the same page
 function postMessageToProxy(message) {
   debug("Sending message to proxy", message);
@@ -92,59 +62,7 @@ function _postMsgToProxy(message) {
 }
 
 // Create button elements above each CodeMirror
-function attachButtons(codeMirrors) {
-  return codeMirrors.map((mirror, index) => {
-    const button = document.createElement("button");
-    button.classList.add("resurface-editor-button");
-    button.classList.add("resurface-stripe");
-    button.innerText = "Open Resurface editor";
-    button.style = `
-        position: absolute;
-        top: 0; left: 0;
-        cursor: pointer;
-        padding: 12px;
-        border: none;
-        border-radius: 4px;
-        background-color: ${buttonBg};
-        color: ${buttonText};
-        z-index: 5;
-        `; // z-index 5 is required for Squarespace (might need to change per platform)
-    button.addEventListener(
-      "click",
-      () =>
-        postMessageToProxy({
-          type: "openEditor",
-          recipient: "service-worker",
-          mirrorId: index,
-        }),
-      false
-    );
 
-    // Attach mirrorIds
-    button.dataset.resurfaceMirrorId = index;
-    mirror.dataset.resurfaceMirrorId = index;
-    mirror.appendChild(button); // Attach button to CodeMirror
-    enableMirror(index); // Enable the mirror for editing in case it was disabled earlier
-    return button;
-  });
-}
-
-/*
-    Converts Monaco changes
-    https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IModelContentChange.html#text
-    
-    to CodeMirror replaceRange from/to args
-    https://codemirror.net/doc/manual.html#api
-*/
-function translateMonacoChanges(monacoChanges) {
-  return monacoChanges.map((change) => {
-    const { range, text: replacement } = change;
-    const { startColumn, startLineNumber, endColumn, endLineNumber } = range;
-    const from = { line: startLineNumber - 1, ch: startColumn - 1 };
-    const to = { line: endLineNumber - 1, ch: endColumn - 1 };
-    return { replacement, from, to };
-  });
-}
 
 // Listen for events from proxy content script running on the same page
 function listen() {
@@ -169,79 +87,30 @@ function handleMessage(event) {
   const { mirrorId: mirrorId, type } = event.data;
   if (type === "disabled") return destroy();
   if (!mirrorId && mirrorId !== 0) return error("Invalid mirrorId:", mirrorId);
-  const codeMirror = getCodeMirrorById(mirrorId);
+  const codeMirror = codeMirrors.getCodeInputById(mirrorId);
   if (!codeMirror) return error("Could not find CodeMirror with ID:", mirrorId);
 
   switch (type) {
     case "portConnected":
-      disableMirror(mirrorId);
+      codeMirrors.disableInput(mirrorId);
       break;
     case "portDisconnected":
-      enableMirror(mirrorId);
+      codeMirrors.enableInput(mirrorId);
       break;
     case "populateEditorRequest":
       postMessageToProxy({
         type: "populateEditorResponse",
-        value: getValue(codeMirror),
+        value: codeMirrors.getValue(mirrorId),
         recipient: "editor",
       });
       break;
     case "editorChanged":
       const { changes } = event.data;
-      const translated = translateMonacoChanges(changes);
-      translated.forEach((change) => {
-        const { replacement, from, to } = change;
-        codeMirror.CodeMirror.doc.replaceRange(replacement, from, to);
-      });
+      codeMirrors.editorChanged(mirrorId, changes)
       break;
     default:
       error("Received unknown message type:", event.data);
   }
-}
-
-// Prevents a code mirror from being edited
-function preventKeyboardEntry(_cm, event) {
-  event.preventDefault();
-}
-
-// Returns codeMirror DOM element by ID index
-function getCodeMirrorById(mirrorId) {
-  return codeMirrors.find(
-    (mirror) => mirror.dataset.resurfaceMirrorId === mirrorId.toString()
-  );
-}
-
-// Enables a given code mirror for editing
-function enableMirror(mirrorId) {
-  const codeMirror = getCodeMirrorById(mirrorId);
-  if (!codeMirror) return;
-  codeMirror.style.opacity = 1;
-  codeMirror.CodeMirror.off("keydown", preventKeyboardEntry);
-  toggleButton(mirrorId, true);
-}
-
-// Disables a given code mirror so that it cannot be edited
-function disableMirror(mirrorId) {
-  const codeMirror = getCodeMirrorById(mirrorId);
-  if (!codeMirror) return;
-  codeMirror.style.opacity = 0.5;
-  codeMirror.CodeMirror.on("keydown", preventKeyboardEntry);
-  toggleButton(mirrorId, false);
-}
-
-// Enables/disables the open editor button
-function toggleButton(mirrorId, enabled) {
-  const button = buttons.find(
-    (button) => button.dataset.resurfaceMirrorId === mirrorId.toString()
-  );
-  if (!button) return;
-  button.disabled = !enabled;
-  button.innerText = enabled
-    ? "Open Resurface editor"
-    : "(editing via Resurface)";
-  button.style.backgroundColor = enabled ? buttonBg : "transparent";
-  button.style.cursor = enabled ? "pointer" : "default";
-  button.style.color = enabled ? buttonText : "black";
 }
 
 // Poll page 10 times until CodeMirror is found

--- a/browser-extension/src/content-scripts/proxy.js
+++ b/browser-extension/src/content-scripts/proxy.js
@@ -72,12 +72,12 @@ chrome.runtime.onMessage.addListener(onChromeMessage);
 async function listen(message) {
   debug("Received message:", message);
   const { tabId } = await chrome.runtime.sendMessage({ type: "getTabId" });
-  const { editorId, recipientId, type, mirrorId } = message;
+  const { editorId, recipientId, type, targetId } = message;
   if (recipientId !== tabId) return { success: false };
   switch (type) {
     case "connect":
       window.__RESURFACE__.port = chrome.runtime.connect({
-        name: `${editorId}-${recipientId}-${mirrorId}`,
+        name: `${editorId}-${recipientId}-${targetId}`,
       });
 
       window.__RESURFACE__.port.onMessage.addListener((message) => {
@@ -86,11 +86,11 @@ async function listen(message) {
       });
 
       window.__RESURFACE__.port.onDisconnect.addListener(() => {
-        debug(`Port for mirror ${mirrorId} disconnected`);
-        postMessageToDom({ type: "portDisconnected", mirrorId });
+        debug(`Port for mirror ${targetId} disconnected`);
+        postMessageToDom({ type: "portDisconnected", targetId });
       });
 
-      postMessageToDom({ type: "portConnected", mirrorId });
+      postMessageToDom({ type: "portConnected", targetId });
       return { success: true };
     default:
       warn("Unknown message type:", type);

--- a/browser-extension/src/lib/inputs.js
+++ b/browser-extension/src/lib/inputs.js
@@ -1,0 +1,245 @@
+
+const buttonBg = "#133d65";
+const buttonText = "white";
+class ResurfaceInput {
+
+  constructor(postMsg) {
+    this.elements = []
+    this.postMessageToProxy = postMsg
+    this.findInputs()
+    this.buttons = this.attachButtons()
+  }
+
+  findInputs() {
+    throw new Error("findInputs not implemented")
+  }
+
+  /**
+   * Get a value from the given inputId
+   * @param inputId
+   */
+  getValue(inputId){
+    throw new Error("getValue not implemented")
+  }
+
+  enableInput(inputId){
+    const codeInput = this.getCodeInputById(inputId);
+    if (!codeInput) return;
+    this.enable(codeInput);
+    this.toggleButton(inputId, true);
+  }
+
+  enable(codeInput) {
+    throw new Error("enableInput not implemented")
+  }
+
+  disable(codeInput) {
+    throw new Error("disableInput not implemented")
+  }
+
+  disableInput(inputId) {
+    const codeInput = this.getCodeInputById(inputId);
+    if (!codeInput) return;
+    this.disable(codeInput)
+    this.toggleButton(inputId, false);
+  }
+
+  // Returns codeMirror DOM element by ID index
+  getCodeInputById(mirrorId) {
+    return this.elements.find(
+      (mirror) => mirror.dataset.resurfaceInputId === mirrorId.toString()
+    );
+  }
+
+
+// Enables/disables the open editor button
+  toggleButton(inputId, enabled) {
+    const button = this.buttons.find(
+      (button) => button.dataset.resurfaceInputId === inputId.toString()
+    );
+    if (!button) return;
+    button.disabled = !enabled;
+    button.innerText = enabled
+      ? "Open Resurface editor"
+      : "(editing via Resurface)";
+    button.style.backgroundColor = enabled ? buttonBg : "transparent";
+    button.style.cursor = enabled ? "pointer" : "default";
+    button.style.color = enabled ? buttonText : "black";
+  }
+
+
+  get hasInputs() {
+    return this.elements.length > 0;
+  }
+
+
+
+  destroy() {
+    // Just destory this classes buttons
+    // TODO: Do we need to look for orphaned buttons?
+    //const orphanedButtons = getAllButtons();
+    //const allButtons = (
+    //  orphanedButtons ? [...buttons, ...orphanedButtons] : buttons
+    //).filter(Boolean);
+    this.buttons.forEach((button) => {
+      const mirrorId = button.dataset.resurfaceInputId;
+      this.postMessageToProxy({ type: "closeEditor", mirrorId, recipient: "editor" });
+      button.remove();
+    });
+    this.buttons = [];
+    this.elements = [];
+  }
+
+  attachButtons() {
+    return this.elements.map((mirror, index) => {
+      const button = document.createElement("button");
+      button.classList.add("resurface-editor-button");
+      button.classList.add("resurface-stripe");
+      button.innerText = "Open Resurface editor";
+      button.style = `
+        position: absolute;
+        top: 0; left: 0;
+        cursor: pointer;
+        padding: 12px;
+        border: none;
+        border-radius: 4px;
+        background-color: ${buttonBg};
+        color: ${buttonText};
+        z-index: 5;
+        `; // z-index 5 is required for Squarespace (might need to change per platform)
+      button.addEventListener(
+        "click",
+        () =>
+          this.postMessageToProxy({
+            type: "openEditor",
+            recipient: "service-worker",
+            mirrorId: index,
+          }),
+        false
+      );
+
+      // Attach mirrorIds
+      button.dataset.resurfaceInputId = index;
+      mirror.dataset.resurfaceInputId = index;
+      mirror.appendChild(button); // Attach button to CodeMirror
+      // TODO: buttons have not been initialized yet so this enableInput will not work.
+      //this.enableInput(index); // Enable the mirror for editing in case it was disabled earlier
+      return button;
+    });
+  }
+}
+
+class ResurfaceCodeMirrorInput extends ResurfaceInput {
+
+  preventKeyboardEntry(_cm, event) {
+    event.preventDefault();
+  }
+
+  getValue(inputId){
+    let codeMirror = this.getCodeInputById(inputId)
+    return codeMirror.CodeMirror.doc.getValue();
+  }
+
+// Enables a given code mirror for editing
+  enable(codeMirror) {
+    codeMirror.style.opacity = 1;
+    codeMirror.CodeMirror.off("keydown", this.preventKeyboardEntry);
+  }
+
+// Disables a given code mirror so that it cannot be edited
+  disable(codeMirror) {
+    codeMirror.style.opacity = 0.5;
+    codeMirror.CodeMirror.on("keydown", this.preventKeyboardEntry);
+  }
+
+  findInputs() {
+    const foundMirrors = Array.from(document.querySelectorAll(".CodeMirror"));
+    this.elements = foundMirrors.filter(Boolean);
+  }
+
+  /*
+      Converts Monaco changes
+      https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IModelContentChange.html#text
+
+      to CodeMirror replaceRange from/to args
+      https://codemirror.net/doc/manual.html#api
+  */
+  _translateMonacoChanges(monacoChanges) {
+    return monacoChanges.map((change) => {
+      const { range, text: replacement } = change;
+      const { startColumn, startLineNumber, endColumn, endLineNumber } = range;
+      const from = { line: startLineNumber - 1, ch: startColumn - 1 };
+      const to = { line: endLineNumber - 1, ch: endColumn - 1 };
+      return { replacement, from, to };
+    });
+  }
+
+  editorChanged(inputId, changes) {
+    const codeMirror = this.getCodeInputById(inputId);
+    if (!codeMirror) return;
+
+    const translated = this._translateMonacoChanges(changes);
+    translated.forEach((change) => {
+      const { replacement, from, to } = change;
+      codeMirror.CodeMirror.doc.replaceRange(replacement, from, to);
+    });
+  }
+}
+
+
+class ResurfaceTextareaInput extends ResurfaceInput {
+
+  preventKeyboardEntry(_cm, event) {
+    event.preventDefault();
+  }
+
+  getValue(inputId){
+    let textArea = this.getCodeInputById(inputId)
+    return textArea.value;
+  }
+
+// Enables a given code mirror for editing
+  enable(codeInput) {
+    codeInput.disable = false;
+  }
+
+// Disables a given code mirror so that it cannot be edited
+  disableInput(mirrorId) {
+    codeInput.disable = true;
+  }
+
+  findInputs() {
+    const foundMirrors = Array.from(document.querySelectorAll(".CodeMirror"));
+    this.elements = foundMirrors.filter(Boolean);
+  }
+
+  /*
+      Converts Monaco changes
+      https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IModelContentChange.html#text
+
+      to CodeMirror replaceRange from/to args
+      https://codemirror.net/doc/manual.html#api
+  */
+  _translateMonacoChanges(monacoChanges) {
+    return monacoChanges.map((change) => {
+      const { range, text: replacement } = change;
+      const { startColumn, startLineNumber, endColumn, endLineNumber } = range;
+      const from = { line: startLineNumber - 1, ch: startColumn - 1 };
+      const to = { line: endLineNumber - 1, ch: endColumn - 1 };
+      return { replacement, from, to };
+    });
+  }
+
+  editorChanged(inputId, changes) {
+    //const codeMirror = this.getCodeInputById(inputId);
+    //if (!codeMirror) return;
+
+    //const translated = this._translateMonacoChanges(changes);
+    //translated.forEach((change) => {
+    //  const { replacement, from, to } = change;
+    //  codeMirror.CodeMirror.doc.replaceRange(replacement, from, to);
+    //});
+  }
+}
+
+export {ResurfaceCodeMirrorInput}

--- a/browser-extension/src/lib/inputs.js
+++ b/browser-extension/src/lib/inputs.js
@@ -248,14 +248,14 @@ class ResurfaceInput {
           this.postMessageToProxy({
             type: "openEditor",
             recipient: "service-worker",
-            mirrorId: `${this.prefix}-index`,
+            mirrorId: `${this.prefix}-${index}`,
           })},
         false
       );
 
       // Attach mirrorIds
-      button.dataset.resurfaceInputId = `${this.prefix}-index`;
-      mirror.dataset.resurfaceInputId = `${this.prefix}-index`;
+      button.dataset.resurfaceInputId = `${this.prefix}-${index}`;
+      mirror.dataset.resurfaceInputId = `${this.prefix}-${index}`;
       mirror.appendChild(button); // Attach button to CodeMirror
       // TODO: buttons have not been initialized yet so this enableInput will not work.
       //this.enableInput(index); // Enable the mirror for editing in case it was disabled earlier

--- a/browser-extension/src/lib/inputs.js
+++ b/browser-extension/src/lib/inputs.js
@@ -1,6 +1,53 @@
 
 const buttonBg = "#133d65";
 const buttonText = "white";
+const CODE_MIRROR_PREFIX = 'CM'
+
+class CodeInputs {
+  constructor(postMsg) {
+    this.codeInputs = new Map();
+    this.codeInputs.set(CODE_MIRROR_PREFIX, new ResurfaceCodeMirrorInput(postMsg))
+  }
+
+
+  get hasInputs() {
+    return Array.from(this.codeInputs.values()).reduce((x, hasInputs) => hasInputs || x.hasInputs(), false)
+  }
+
+  destroy() {
+    for (const codeInput of this.codeInputs.values()) {
+      codeInput.destroy();
+    }
+  }
+
+  _getCodeInput(inputId){
+    //split based on -
+    // lookup in map based on prefix
+    // return the value
+    return this.codeInputs.get(inputId.split("-")[0])
+  }
+
+  disableInput(inputId) {
+    this._getCodeInput(inputId).disableInput(inputId)
+  }
+
+  enableInput(inputId) {
+    this._getCodeInput(inputId).enableInput(inputId)
+  }
+
+  getValue(inputId) {
+    return this._getCodeInput(inputId).getValue(inputId)
+  }
+
+  editorChanged(inputId, changes) {
+    this._getCodeInput(inputId).editorChanged(inputId, changes)
+  }
+
+  getCodeInputById(inputId) {
+    return this._getCodeInput(inputId).getCodeInputById(inputId)
+  }
+}
+
 class ResurfaceInput {
 
   constructor(postMsg) {
@@ -20,6 +67,11 @@ class ResurfaceInput {
    */
   getValue(inputId){
     throw new Error("getValue not implemented")
+  }
+
+
+  get prefix(){
+    throw new Error("prefix not implmented")
   }
 
   enableInput(inputId){
@@ -113,14 +165,14 @@ class ResurfaceInput {
           this.postMessageToProxy({
             type: "openEditor",
             recipient: "service-worker",
-            mirrorId: index,
+            mirrorId: `${this.prefix}-index`,
           }),
         false
       );
 
       // Attach mirrorIds
-      button.dataset.resurfaceInputId = index;
-      mirror.dataset.resurfaceInputId = index;
+      button.dataset.resurfaceInputId = `${this.prefix}-index`;
+      mirror.dataset.resurfaceInputId = `${this.prefix}-index`;
       mirror.appendChild(button); // Attach button to CodeMirror
       // TODO: buttons have not been initialized yet so this enableInput will not work.
       //this.enableInput(index); // Enable the mirror for editing in case it was disabled earlier
@@ -130,6 +182,10 @@ class ResurfaceInput {
 }
 
 class ResurfaceCodeMirrorInput extends ResurfaceInput {
+
+  get prefix(){
+    return CODE_MIRROR_PREFIX
+  }
 
   preventKeyboardEntry(_cm, event) {
     event.preventDefault();
@@ -242,4 +298,4 @@ class ResurfaceTextareaInput extends ResurfaceInput {
   }
 }
 
-export {ResurfaceCodeMirrorInput}
+export {ResurfaceCodeMirrorInput, CodeInputs}

--- a/browser-extension/src/lib/sentry.js
+++ b/browser-extension/src/lib/sentry.js
@@ -2,13 +2,13 @@ import { init, captureException } from "@sentry/browser";
 import { BrowserTracing } from "@sentry/tracing";
 
 export function sentryInit() {
-  init({
-    dsn: "https://5dcc5b13db974a6ba5c850d90a18c565@o1271690.ingest.sentry.io/6464314",
-    integrations: [new BrowserTracing()],
-    tracesSampleRate: 1.0,
-  });
+  //init({
+  //  dsn: "https://5dcc5b13db974a6ba5c850d90a18c565@o1271690.ingest.sentry.io/6464314",
+  //  integrations: [new BrowserTracing()],
+  //  tracesSampleRate: 1.0,
+  //});
 }
 
 export function sentryError(error) {
-  captureException(error);
+  //captureException(error);
 }

--- a/browser-extension/src/lib/targets.js
+++ b/browser-extension/src/lib/targets.js
@@ -5,14 +5,14 @@ const CODE_MIRROR_PREFIX = 'CM'
 const TEXTAREA_PREFIX = 'TA'
 
 /**
- * CodeInputs is the main interface used from main.js to initialize all code inputs on a page that can be used with
+ * ResurfaceTargets is the main interface used from main.js to initialize all code inputs on a page that can be used with
  * resurface.
  */
-class CodeInputs {
+class ResurfaceTargets {
   constructor(postMsg) {
-    this.codeInputs = new Map();
-    this.codeInputs.set(CODE_MIRROR_PREFIX, new ResurfaceCodeMirrorInput(postMsg))
-    this.codeInputs.set(TEXTAREA_PREFIX, new ResurfaceTextareaInput(postMsg))
+    this.resurfaceInstances = new Map();
+    this.resurfaceInstances.set(CODE_MIRROR_PREFIX, new ResurfaceCodeMirrorTarget(postMsg))
+    this.resurfaceInstances.set(TEXTAREA_PREFIX, new ResurfaceTextareaTarget(postMsg))
   }
 
   /**
@@ -20,7 +20,7 @@ class CodeInputs {
    * @returns {boolean} True if there are code elements on page, false otherwise.
    */
   static hasCodeElements(){
-    return ResurfaceTextareaInput.hasCodeElements() || ResurfaceCodeMirrorInput.hasCodeElements();
+    return ResurfaceTextareaTarget.hasCodeElements() || ResurfaceCodeMirrorTarget.hasCodeElements();
   }
 
   /**
@@ -28,26 +28,26 @@ class CodeInputs {
    * @returns {boolean} True if there are already intialized ResurfaceInputs on the page, false otherwise.
    */
   get hasInputs() {
-    return Array.from(this.codeInputs.values()).reduce((x, hasInputs) => hasInputs || x.hasInputs(), false)
+    return Array.from(this.resurfaceInstances.values()).reduce((x, hasInputs) => hasInputs || x.hasInputs(), false)
   }
 
   /**
    * Destroy all inputs that have been initialized.
    */
   destroy() {
-    for (const codeInput of this.codeInputs.values()) {
-      codeInput.destroy();
+    for (const resurfaceInstance of this.resurfaceInstances.values()) {
+      resurfaceInstance.destroy();
     }
   }
 
   /**
    * Helper function to get ResurfaceInput instance used for a given ID
    * @param inputId - the ID of the element
-   * @returns {ResurfaceInput} The initialized ResurfaceInput instance to use for the ID
+   * @returns {ResurfaceTarget} The initialized ResurfaceInput instance to use for the ID
    * @private
    */
-  _getCodeInput(inputId){
-    return this.codeInputs.get(inputId.split("-")[0])
+  _getResurfaceInstance(inputId){
+    return this.resurfaceInstances.get(inputId.split("-")[0])
   }
 
   /**
@@ -55,7 +55,7 @@ class CodeInputs {
    * @param inputId - ID of input to disable
    */
   disableInput(inputId) {
-    this._getCodeInput(inputId).disableInput(inputId)
+    this._getResurfaceInstance(inputId).disableInput(inputId)
   }
 
   /**
@@ -63,7 +63,7 @@ class CodeInputs {
    * @param inputId - ID of input to enable
    */
   enableInput(inputId) {
-    this._getCodeInput(inputId).enableInput(inputId)
+    this._getResurfaceInstance(inputId).enableInput(inputId)
   }
 
   /**
@@ -72,7 +72,7 @@ class CodeInputs {
    * @returns {string} The current value of the input on the page.
    */
   getValue(inputId) {
-    return this._getCodeInput(inputId).getValue(inputId)
+    return this._getResurfaceInstance(inputId).getValue(inputId)
   }
 
   /**
@@ -82,7 +82,7 @@ class CodeInputs {
    *        https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IModelContentChange.html#text
    */
   editorChanged(inputId, changes) {
-    this._getCodeInput(inputId).editorChanged(inputId, changes)
+    this._getResurfaceInstance(inputId).editorChanged(inputId, changes)
   }
 
   /**
@@ -90,8 +90,8 @@ class CodeInputs {
    * @param inputId The ID of the element to get
    * @returns {*} DOM element for the given ID
    */
-  getCodeInputById(inputId) {
-    return this._getCodeInput(inputId).getCodeInputById(inputId)
+  getResurfaceTargetById(inputId) {
+    return this._getResurfaceInstance(inputId).getResurfaceTargetById(inputId)
   }
 }
 
@@ -105,7 +105,7 @@ class CodeInputs {
  *    - enable
  *    - disable
  */
-class ResurfaceInput {
+class ResurfaceTarget {
 
   constructor(postMsg) {
     this.elements = []
@@ -138,39 +138,39 @@ class ResurfaceInput {
   }
 
   /**
-   * Getter for the prefix. Each class that inherits from ResurfaceInput needs a unique prefix
+   * Getter for the prefix. Each class that inherits from ResurfaceTarget needs a unique prefix
    */
   get prefix(){
     throw new Error("prefix not implmented")
   }
 
   enableInput(inputId){
-    const codeInput = this.getCodeInputById(inputId);
-    if (!codeInput) return;
-    this.enable(codeInput);
+    const resurfaceTarget = this.getResurfaceTargetById(inputId);
+    if (!resurfaceTarget) return;
+    this.enable(resurfaceTarget);
     this.toggleButton(inputId, true);
   }
 
   /**
    * Given a DOM element enable it for editing
-   * @param codeInput The DOM element stored in `this.elements`
+   * @param resurfaceTarget The DOM element stored in `this.elements`
    */
-  enable(codeInput) {
+  enable(resurfaceTarget) {
     throw new Error("enableInput not implemented")
   }
 
   /**
    * Given a DOM element disable it for editing
-   * @param codeInput The DOM element stored in `this.elements`
+   * @param resurfaceTarget The DOM element stored in `this.elements`
    */
-  disable(codeInput) {
+  disable(resurfaceTarget) {
     throw new Error("disableInput not implemented")
   }
 
   disableInput(inputId) {
-    const codeInput = this.getCodeInputById(inputId);
-    if (!codeInput) return;
-    this.disable(codeInput)
+    const resurfaceTarget = this.getResurfaceTargetById(inputId);
+    if (!resurfaceTarget) return;
+    this.disable(resurfaceTarget)
     this.toggleButton(inputId, false);
   }
 
@@ -179,7 +179,7 @@ class ResurfaceInput {
    * @param inputId - The ID to get the DOM element for
    * @returns {*} DOM element for the ID
    */
-  getCodeInputById(inputId) {
+  getResurfaceTargetById(inputId) {
     return this.elements.find(
       (el) => el.dataset.resurfaceInputId === inputId.toString()
     );
@@ -216,8 +216,8 @@ class ResurfaceInput {
     //  orphanedButtons ? [...buttons, ...orphanedButtons] : buttons
     //).filter(Boolean);
     this.buttons.forEach((button) => {
-      const mirrorId = button.dataset.resurfaceInputId;
-      this.postMessageToProxy({ type: "closeEditor", mirrorId, recipient: "editor" });
+      const targetId = button.dataset.resurfaceInputId;
+      this.postMessageToProxy({ type: "closeEditor", targetId, recipient: "editor" });
       button.remove();
     });
     this.buttons = [];
@@ -245,12 +245,12 @@ class ResurfaceInput {
   }
 
   attachButtons() {
-    return this.elements.map((mirror, index) => {
+    return this.elements.map((codeElement, index) => {
       const button = document.createElement("button");
       button.classList.add("resurface-editor-button");
       button.classList.add("resurface-stripe");
       button.innerText = "Open Resurface editor";
-      button.style = this.getButtonStyle(mirror);
+      button.style = this.getButtonStyle(codeElement);
       button.addEventListener(
         "click",
         (evt) =>{
@@ -258,15 +258,15 @@ class ResurfaceInput {
           this.postMessageToProxy({
             type: "openEditor",
             recipient: "service-worker",
-            mirrorId: `${this.prefix}-${index}`,
+            targetId: `${this.prefix}-${index}`,
           })},
         false
       );
 
-      // Attach mirrorIds
+      // Attach targetIds
       button.dataset.resurfaceInputId = `${this.prefix}-${index}`;
-      mirror.dataset.resurfaceInputId = `${this.prefix}-${index}`;
-      mirror.parentNode.insertBefore(button, mirror); // Attach button to target
+      codeElement.dataset.resurfaceInputId = `${this.prefix}-${index}`;
+      codeElement.parentNode.insertBefore(button, codeElement); // Attach button to target
       // TODO: buttons have not been initialized yet so this enableInput will not work.
       //this.enableInput(index); // Enable the mirror for editing in case it was disabled earlier
       return button;
@@ -274,7 +274,7 @@ class ResurfaceInput {
   }
 }
 
-class ResurfaceCodeMirrorInput extends ResurfaceInput {
+class ResurfaceCodeMirrorTarget extends ResurfaceTarget {
 
   get prefix(){
     return CODE_MIRROR_PREFIX
@@ -289,7 +289,7 @@ class ResurfaceCodeMirrorInput extends ResurfaceInput {
   }
 
   getValue(inputId){
-    let codeMirror = this.getCodeInputById(inputId)
+    let codeMirror = this.getResurfaceTargetById(inputId)
     return codeMirror.CodeMirror.doc.getValue();
   }
 
@@ -328,7 +328,7 @@ class ResurfaceCodeMirrorInput extends ResurfaceInput {
   }
 
   editorChanged(inputId, changes) {
-    const codeMirror = this.getCodeInputById(inputId);
+    const codeMirror = this.getResurfaceTargetById(inputId);
     if (!codeMirror) return;
 
     const translated = this._translateMonacoChanges(changes);
@@ -340,7 +340,7 @@ class ResurfaceCodeMirrorInput extends ResurfaceInput {
 }
 
 
-class ResurfaceTextareaInput extends ResurfaceInput {
+class ResurfaceTextareaTarget extends ResurfaceTarget {
 
   get prefix(){
     return TEXTAREA_PREFIX;
@@ -355,18 +355,18 @@ class ResurfaceTextareaInput extends ResurfaceInput {
   }
 
   getValue(inputId){
-    let textArea = this.getCodeInputById(inputId)
+    let textArea = this.getResurfaceTargetById(inputId)
     return textArea.value;
   }
 
-// Enables a given code mirror for editing
-  enable(codeInput) {
-    codeInput.disabled = false;
+  // Enables a given text area for editing
+  enable(resurfaceTarget) {
+    resurfaceTarget.disabled = false;
   }
 
-// Disables a given code mirror so that it cannot be edited
-  disable(codeInput) {
-    codeInput.disabled = true;
+  // Disables a given text area so that it cannot be edited
+  disable(resurfaceTarget) {
+    resurfaceTarget.disabled = true;
   }
 
   findInputs() {
@@ -376,14 +376,14 @@ class ResurfaceTextareaInput extends ResurfaceInput {
 
 
   editorChanged(inputId, changes) {
-    const codeInput = this.getCodeInputById(inputId);
-    if (!codeInput) return;
+    const resurfaceTarget = this.getResurfaceTargetById(inputId);
+    if (!resurfaceTarget) return;
 
     changes.forEach((change) => {
-      codeInput.setRangeText(change.text, change.rangeOffset, change.rangeOffset + change.rangeLength);
+      resurfaceTarget.setRangeText(change.text, change.rangeOffset, change.rangeOffset + change.rangeLength);
     });
   }
 
 }
 
-export {CodeInputs}
+export {ResurfaceTargets}

--- a/browser-extension/src/service-worker.js
+++ b/browser-extension/src/service-worker.js
@@ -75,7 +75,7 @@ async function listen(message, sender) {
           openedWindowId: newWindow.id,
           openerTabId: sender.tab.id,
           openerWindowId: sender.tab.windowId,
-          mirrorId: message.mirrorId,
+          targetId: message.targetId,
         });
       });
 


### PR DESCRIPTION
Refactor that pulls a lot of the functionality from main.js into an input.js classes that can be used to handle more than one input type.

There is a single interface for the following functions:
  - `hasCodeElements`
  - `hasInputs`
  - `destroy`
  - `disableInput`
  - `enableInput`
  - `getValue`
  - `editorChanged`

Main.js class into `CodeInputs` instance passing in an ID. Based on the ID prefix `CodeInputs` knows whether it is a call for a CodeMirror instance or Textarea instance. 

It is easy to add more types of inputs by inheriting from `ResurfaceInput` and implementing the required functions and defining a prefix.

Quick and dirty block diagram:
```
  ┌─────────────────────────────────────────────────────────────────────┐
  │   Main.js                                                           │
  │                                                                     │
  │                                                                     │
  │                                                                     │
  └───────────────────────────────────┬──────▲──────────────────────────┘
                                      │      │
                                      │      │
                                      │      │
┌─────────────────────────────────────┼──────┼──────────────────────────────┐
│                                     │      │                              │
│  CodeInputs          ┌──────────────▼──────┴───────┐                      │
│                      │Lookup ResurfaceInput        │                      │
│                      │by ID prefix                 │                      │
│                      └──┬─────▲───────────────▲─┬──┘                      │
│                         │     │               │ │                         │
│       ┌─────────────────▼─────┴───┐   ┌───────┴─▼─────────────────┐       │
│       │ ResurfaceCodeMirrorInput  │   │ ResurfaceTextareaInput    │       │
│       │                           │   │                           │       │
│       └───────────────────────────┘   └───────────────────────────┘       │
│                                                                           │
└───────────────────────────────────────────────────────────────────────────┘
```